### PR TITLE
Fix dependencies to prevent build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ ament_target_dependencies(
   class_loader
   OpenCV
   rclcpp
+  rclcpp_components
   sensor_msgs
 )
 rclcpp_components_register_nodes(opencv_cam_node "opencv_cam::OpencvCamNode")
@@ -82,6 +83,7 @@ ament_target_dependencies(
   subscriber_node
   class_loader
   rclcpp
+  rclcpp_components
   sensor_msgs
 )
 rclcpp_components_register_nodes(subscriber_node "opencv_cam::ImageSubscriberNode")


### PR DESCRIPTION
Cloned the repo into my workspace and ran into the following error -
```
fatal error: rclcpp_components/register_node_macro.hpp: No such file or directory
 #include "rclcpp_components/register_node_macro.hpp"
```
These changes fixed them. I might've encountered because I've a source build, if someone has a binary build they could confirm this doesn't break anything?
