### PR TITLE
Fixed build using colcon on ROS2 Humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ ament_target_dependencies(
   rclcpp
   rclcpp_components
   sensor_msgs
+  ros2_shared
 )
 rclcpp_components_register_nodes(opencv_cam_node "opencv_cam::OpencvCamNode")
 set(node_plugins "${node_plugins}opencv_cam::OpencvCamNode;$<TARGET_FILE:opencv_cam_node>\n")


### PR DESCRIPTION
Fix for a build issue:

```
--- stderr: opencv_cam                                 
In file included from /home/clairbee/openvmp/platform/src/third_party/opencv_cam/include/opencv_cam/opencv_cam_node.hpp:10,
                 from /home/clairbee/openvmp/platform/src/third_party/opencv_cam/src/opencv_cam_node.cpp:1:
/home/clairbee/openvmp/platform/src/third_party/opencv_cam/include/opencv_cam/camera_context.hpp:7:10: fatal error: ros2_shared/context_macros.hpp: No such file or directory
    7 | #include "ros2_shared/context_macros.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/opencv_cam_node.dir/build.make:76: CMakeFiles/opencv_cam_node.dir/src/opencv_cam_node.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:143: CMakeFiles/opencv_cam_node.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< opencv_cam [12.3s, exited with code 2]
```